### PR TITLE
Atualiza dependencia para funcionar no laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "php":"^7.0",
     "php-di/php-di": "^6.0",
     "guzzlehttp/guzzle": "^6.3",
-    "monolog/monolog": "^1.17",
+    "monolog/monolog": "^2.0",
     "tiagosampaio/data-object": "^1.0",
     "tiagosampaio/event-observer": "^1.0"
   },


### PR DESCRIPTION
O monolog ta dando conflito no Laravel 8, a versão mínima é 2.0 na nova versão.